### PR TITLE
Dependency parse error

### DIFF
--- a/src/main/java/Capsule.java
+++ b/src/main/java/Capsule.java
@@ -881,7 +881,7 @@ public class Capsule implements Runnable, FileVisitor<Path> {
         if (appName == null)
             appName = getAttribute(ATTR_APP_NAME);
         if (appName == null) {
-            appName = getApplicationArtifactId(getAppArtifact(args));
+            appName = getAppArtifact(args);
             if (appName != null)
                 return getAppArtifactLatestVersion(appName);
         }


### PR DESCRIPTION
Method getAppArtifactLatestVersion(appName) was receiving the appName with "_" separator instead of ":", causing internal pattern matching to fail. 

The following error message was then displayed: 
CAPSULE EXCEPTION: Could not parse dependency: foo_bar_jar (for stack trace, run with -Dcapsule.log=verbose)

Removed the method call that replaced the ":" separator for "_".
