### PR TITLE
Added support for commas in the list attribute

### DIFF
--- a/capsule/src/main/java/Capsule.java
+++ b/capsule/src/main/java/Capsule.java
@@ -1605,12 +1605,13 @@ public class Capsule implements Runnable {
 
     /**
      * Returns the value of the given attribute (with consideration to the capsule's mode) as a list.
-     * The items comprising attribute's value must be whitespace-separated.
+     * The items comprising attribute's value must be comma or whitespace-separated.
      *
      * @param attr the attribute
      */
     protected final List<String> getListAttribute(String attr) {
-        return split(getAttribute(attr), "\\s+");
+        final String val = getAttribute(attr);
+        return val != null && val.contains(",") ? split(val, ",+") : split(val, "\\s+"); // look for comma first, otherwise spaces
     }
 
     /**


### PR DESCRIPTION
Basically I was used to doing `export CAPSULE_REPOS=local,central` and tried to apply the same value to the `Repositories` manifest entry, namely, `Repositories: local,central`. However this does not work, as capsule only supports spacing here, so you would need `Repositories: local central`. Personally I think it should be consistent, it just makes things easier for users.

The change makes it so `Repositories: local central`, `Repositories: local,central` & `Repositories: local, central` works.

Also for mistakes such as the following work too:

`Repositories: ,local`
`Repositories: local,`
`Repositories: local, ,`
`Repositories: , local`
