### PR TITLE
Addition to README.md stating Capsule's support for 'mixed' capsules

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Instead of specifying the dependencies and (optionally) the repositories directl
 
 In order to support Maven dependencies, we needed to include all of Capsule's classes in the capsule JAR rather than just the `Capsule` class. This will add about 1.5MB to the (compressed) JAR, but will save a lot more by not embedding all the dependencies.
 
+Apart from the *thin* and *fat* extremes, Capsule supports anything in between: it is possible to embed some dependencies while declaring others in the manifest (or `pom.xml`) and letting Capsule retrieve them upon first run. Please note that whenever a capsule needs to retrieve even just some Maven artifacts, its JAR needs to include all of Capsule's classes.
+
 Finally, a capsule may not contain any of the application's classes/JARs at all. The capsule's manifest can contain these two attributes:
 
     Main-Class: Capsule


### PR DESCRIPTION
Hi Ron,

I noticed that for some people (including me at the beginning) it's not entirely clear that Capsule supports not just _fat_ and _thin_ layouts but anything in between.

What do you think of this small addition to README.md?

Thx! - Fabio
