### PR TITLE
Fix bugs related to finding the java home of JDKs

### DIFF
--- a/capsule/src/main/java/Capsule.java
+++ b/capsule/src/main/java/Capsule.java
@@ -963,7 +963,7 @@ public class Capsule implements Runnable {
     }
 
     void printJVMs(List<String> args) {
-        final Map<String, Path> jres = getJavaHomes();
+        final Map<String, Path> jres = getJavaHomes(false);
         if (jres == null)
             println("No detected Java installations");
         else {
@@ -2260,7 +2260,7 @@ public class Capsule implements Runnable {
         Path jhome = null;
         if (!"current".equals(propJHome)) {
             jhome = propJHome != null ? Paths.get(propJHome) : null;
-            if (jhome == null && !isMatchingJavaVersion(getProperty(PROP_JAVA_VERSION))) {
+            if (jhome == null) {
                 final boolean jdk = Boolean.parseBoolean(getAttribute(ATTR_JDK_REQUIRED));
 
                 jhome = findJavaHome(jdk);
@@ -2281,10 +2281,8 @@ public class Capsule implements Runnable {
         return jhome != null ? jhome.toAbsolutePath() : jhome;
     }
 
-    private Path findJavaHome(boolean jdk) {
-        Map<String, Path> homes = nullToEmpty(getJavaHomes());
-        if (jdk)
-            homes = getJDKs(homes);
+    private Path findJavaHome(boolean requireJdk) {
+        Map<String, Path> homes = nullToEmpty(getJavaHomes(requireJdk));
         Path best = null;
         String bestVersion = null;
         for (Map.Entry<String, Path> e : homes.entrySet()) {
@@ -3324,7 +3322,7 @@ public class Capsule implements Runnable {
      *
      * @return a map from installations' versions to their respective paths
      */
-    protected static Map<String, Path> getJavaHomes() {
+    protected static Map<String, Path> getJavaHomes(boolean requireJdk) {
         if (JAVA_HOMES == null) {
             try {
                 Path homesDir = null;
@@ -3334,9 +3332,9 @@ public class Capsule implements Runnable {
                         break;
                     }
                 }
-                Map<String, Path> homes = getJavaHomes(homesDir);
+                Map<String, Path> homes = getJavaHomes(homesDir, requireJdk);
                 if (homes != null && isWindows())
-                    homes = windowsJavaHomesHeuristics(homesDir, homes);
+                    homes = windowsJavaHomesHeuristics(homesDir, homes, requireJdk);
                 JAVA_HOMES = homes;
             } catch (IOException e) {
                 throw rethrow(e);
@@ -3345,7 +3343,7 @@ public class Capsule implements Runnable {
         return JAVA_HOMES;
     }
 
-    private static Map<String, Path> windowsJavaHomesHeuristics(Path dir, Map<String, Path> homes) throws IOException {
+    private static Map<String, Path> windowsJavaHomesHeuristics(Path dir, Map<String, Path> homes, boolean requireJdk) throws IOException {
         Path dir2 = null;
         if (dir.startsWith(WINDOWS_PROGRAM_FILES_1))
             dir2 = WINDOWS_PROGRAM_FILES_2.resolve(WINDOWS_PROGRAM_FILES_1.relativize(dir));
@@ -3353,13 +3351,16 @@ public class Capsule implements Runnable {
             dir2 = WINDOWS_PROGRAM_FILES_1.resolve(WINDOWS_PROGRAM_FILES_2.relativize(dir));
         if (dir2 != null) {
             Map<String, Path> allHomes = new HashMap<>(homes);
-            allHomes.putAll(getJavaHomes(dir2));
+            Map<String, Path> allHomes2 = getJavaHomes(dir2, requireJdk);
+            if (allHomes2 != null) {
+                allHomes.putAll(allHomes2);
+            }
             return allHomes;
         } else
             return homes;
     }
 
-    private static Map<String, Path> getJavaHomes(Path dir) throws IOException {
+    private static Map<String, Path> getJavaHomes(Path dir, boolean requireJdk) throws IOException {
         if (dir == null || !Files.isDirectory(dir))
             return null;
         final Map<String, Path> dirs = new HashMap<String, Path>();
@@ -3367,16 +3368,27 @@ public class Capsule implements Runnable {
             for (Path f : fs) {
                 String ver;
                 Path home;
-                if (Files.isDirectory(f) && (ver = isJavaDir(f.getFileName().toString())) != null
-                        && (home = searchJavaHomeInDir(f)) != null) {
-                    home = home.toAbsolutePath();
-                    if (parseJavaVersion(ver)[3] == 0)
-                        ver = getActualJavaVersion(home);
-                    dirs.put(ver, home);
+                if (Files.isDirectory(f) && (ver = isJavaDir(f.getFileName().toString())) != null) {
+                    if (isJavaHome(f) && (!requireJdk || isJDK(f))) {
+                        storeJavaHome(dirs, ver, f);
+                    }
+                    else {
+                        home = searchJavaHomeInDir(f);
+                        if (home != null && (!requireJdk || isJDK(home))) {
+                            storeJavaHome(dirs, ver, home);
+                        }
+                    }
                 }
             }
         }
         return emptyToNull(dirs);
+    }
+
+    private static void storeJavaHome(Map<String, Path> result, String version, Path path) {
+        Path home = path.toAbsolutePath();
+        if (parseJavaVersion(version)[3] == 0)
+            version = getActualJavaVersion(home);
+        result.put(version, home);
     }
 
     // visible for testing


### PR DESCRIPTION
There are a few bugs in Capsule related to finding a JDK instead of a JRE to run the application. I encountered these problems when using a capsule with a manifest that has a line 'JDK-Required: true'.


**Problem 1:**
Let's say we have a computer that has a single version of Java installed: JDK 1.8.0_25 which includes the JRE with the same version 1.8.0_25.
The user double clicks on a capsule jar and this jar is executed by the JRE. The manifest of this jar has the line 'JDK-Required: true', so we need to find a JDK.

On line 2264 there is a call to isMatchingJavaVersion:
    if (jhome == null && !isMatchingJavaVersion(getProperty(PROP_JAVA_VERSION))) {

Since the version of the JDK and the JRE are the same (both have version 1.8.0_25), the search for the JDK will be aborted and the current jhome (of the JRE) will be used. This is wrong, since we need a JDK not a JRE.

This can simply be fixed by removing the call to isMatchingJavaVersion.


**Problem 2:**
Capsule will find all installed JREs and all installed JDKs. The versions and directories that are found are stored in a HashMap. The version is used as the key and the directory as the value.

When both a JDK and a JRE are found with the same version, only one of them will be in the resulting Map. When the version number of the JDK and JRE are the same, one will overwrite the other in this Map.

The filtering to restrict the java homes to only JDKs is done after the Map has been populated. At this point (if you are unlucky) the information about the JDKs may have been lost and only information about the JREs remains in the map. Since a JDK was requested and cannot be found, the execution of the Capsule will fail with an error.

The solution is to push down the JDK filter, so it is done while searching for java homes and before populating the map.


**Problem 3:**
When the method getJavaHomes finds a directory that contains a JDK, it will call the method searchJavaHomeInDir. The jdk directory may contain a jre directory. This jre directory will be found by searchJavaHomeInDir and will be used instead of the directory that contains the JDK. In case JDK-Required is equal to true, this behavior results in incorrectly not finding the JDK.


This pull request also contains a fix for bug #49.