### PR TITLE
Fix pathing JAR on Windows when the classpath contains jars on different drives

### DIFF
--- a/capsule/src/main/java/Capsule.java
+++ b/capsule/src/main/java/Capsule.java
@@ -3130,9 +3130,7 @@ public class Capsule implements Runnable {
     static Path createPathingJar(Path dir, List<Path> cp) {
         try {
             dir = dir.toAbsolutePath();
-            final List<Path> paths = new ArrayList<>(cp.size());
-            for (Path p : cp) // In order to use the Class-Path attribute, we must either relativize the paths, or specifiy them as file URLs
-                paths.add(dir.relativize(p));
+            final List<String> paths = createClassPath(dir, cp);
 
             final Path pathingJar = Files.createTempFile(dir, "capsule_pathing_jar", ".jar");
             final Manifest man = new Manifest();
@@ -3144,6 +3142,23 @@ public class Capsule implements Runnable {
         } catch (IOException e) {
             throw new RuntimeException("Pathing JAR creation failed", e);
         }
+    }
+
+    private static List<String> createClassPath(Path dir, List<Path> cp) {
+        boolean allPathsHaveSameRoot = true;
+        for (Path p : cp) {
+            if (! dir.getRoot().equals(p.getRoot()))
+                allPathsHaveSameRoot = false;
+        }
+
+        final List<String> paths = new ArrayList<>(cp.size());
+        for (Path p : cp) { // In order to use the Class-Path attribute, we must either relativize the paths, or specifiy them as file URLs
+            if (allPathsHaveSameRoot)
+                paths.add(dir.relativize(p).toString());
+            else
+                paths.add(p.toUri().toString());
+        }
+        return paths;
     }
     //</editor-fold>
 


### PR DESCRIPTION
I have made a capsule jar available on a Windows network share. Windows users have mapped this share to a drive letter. For example E: . They can start the application by navigating to the E: drive and double clicking on the jar file.

Capsule will store jar files in the temp directory, which is usually located on the C: drive. The capsule jar is included in the classpath. So the resulting classpath contains jars on the C: drive and the E: drive.

The method createPathingJar tries to convert the absolute paths of the jars into relative paths. Because the jars are on different drives, this fails with an IllegalArgumentException about the "root" (=drive letter) of the path being different (The exact exception message is: 'other' has different root).

This pull request checks if the roots of all the paths are the same. If so, it will relativize the paths as before. If the roots are different, it will use file URLs instead of paths to construct the classpath.