### PR TITLE
While resolving dependencies, the java.home property is not correct.

### DIFF
--- a/capsule/src/main/java/Capsule.java
+++ b/capsule/src/main/java/Capsule.java
@@ -2395,7 +2395,7 @@ public class Capsule implements Runnable {
         try {
             final boolean reset = systemPropertyEmptyOrTrue(PROP_RESET);
             final Path localRepo = getLocalRepo();
-            return createDependencyManager(localRepo.toAbsolutePath(), reset, oc.logLevel);
+            return createDependencyManager(localRepo.toAbsolutePath(), reset, oc.logLevel, javaHome_.toString());
         } catch (NoClassDefFoundError e) {
             return null;
         }
@@ -2404,8 +2404,8 @@ public class Capsule implements Runnable {
     /**
      * @deprecated marked deprecated to exclude from javadoc.
      */
-    protected Object createDependencyManager(Path localRepo, boolean reset, int logLevel) {
-        return new DependencyManagerImpl(localRepo, reset, logLevel);
+    protected Object createDependencyManager(Path localRepo, boolean reset, int logLevel, String javaHome) {
+        return new DependencyManagerImpl(localRepo, reset, logLevel, javaHome);
     }
 
     private Object getDependencyManager() {

--- a/capsule/src/main/java/capsule/DependencyManagerImpl.java
+++ b/capsule/src/main/java/capsule/DependencyManagerImpl.java
@@ -81,6 +81,7 @@ public class DependencyManagerImpl implements DependencyManager {
     private static final int LOG_VERBOSE = 2;
     private static final int LOG_DEBUG = 3;
     private static final String LOG_PREFIX = "CAPSULE: ";
+    private static final String JAVA_HOME = "java.home";
     //</editor-fold>
 
     private final boolean forceRefresh;
@@ -94,7 +95,7 @@ public class DependencyManagerImpl implements DependencyManager {
     //<editor-fold desc="Construction and Setup">
     /////////// Construction and Setup ///////////////////////////////////
     @SuppressWarnings("OverridableMethodCallInConstructor")
-    public DependencyManagerImpl(Path localRepoPath, boolean forceRefresh, int logLevel) {
+    public DependencyManagerImpl(Path localRepoPath, boolean forceRefresh, int logLevel, String javaHome) {
         this.logLevel = logLevel;
         this.forceRefresh = forceRefresh;
         this.offline = isPropertySet(PROP_OFFLINE, false);
@@ -107,7 +108,7 @@ public class DependencyManagerImpl implements DependencyManager {
         final LocalRepository localRepo = new LocalRepository(localRepoPath.toFile());
         this.settings = UserSettings.getInstance();
         this.system = newRepositorySystem();
-        this.session = newRepositorySession(system, localRepo);
+        this.session = newRepositorySession(system, localRepo, javaHome);
     }
 
     @Override
@@ -163,12 +164,13 @@ public class DependencyManagerImpl implements DependencyManager {
         return locator.getService(RepositorySystem.class);
     }
 
-    protected RepositorySystemSession newRepositorySession(RepositorySystem system, LocalRepository localRepo) {
+    protected RepositorySystemSession newRepositorySession(RepositorySystem system, LocalRepository localRepo, String javaHome) {
         final DefaultRepositorySystemSession s = MavenRepositorySystemUtils.newSession();
 
         s.setConfigProperty(ConfigurationProperties.CONNECT_TIMEOUT, propertyOrEnv(PROP_CONNECT_TIMEOUT, ENV_CONNECT_TIMEOUT));
         s.setConfigProperty(ConfigurationProperties.REQUEST_TIMEOUT, propertyOrEnv(PROP_REQUEST_TIMEOUT, ENV_REQUEST_TIMEOUT));
         s.setConfigProperty(ConflictResolver.CONFIG_PROP_VERBOSE, true);
+        s.setSystemProperty(JAVA_HOME, javaHome);
 
         s.setOffline(offline);
         s.setUpdatePolicy(forceRefresh ? RepositoryPolicy.UPDATE_POLICY_ALWAYS : RepositoryPolicy.UPDATE_POLICY_NEVER);

--- a/capsule/src/test/java/capsule/DependencyManagerDriver.java
+++ b/capsule/src/test/java/capsule/DependencyManagerDriver.java
@@ -23,7 +23,7 @@ public class DependencyManagerDriver {
     public static void main(String[] args) {
         DependencyManager dm;
 
-        dm = new DependencyManagerImpl(DEFAULT_LOCAL_MAVEN, false, 3);
+        dm = new DependencyManagerImpl(DEFAULT_LOCAL_MAVEN, false, 3, "");
         dm.setRepos(null, true);
         
         resolve(dm, "co.paralleluniverse:quasar-core:LATEST");


### PR DESCRIPTION
When resolving dependencies, the java.home property should be set to the home of the target jvm, not the jvm that is running capsule.

I have an application that makes a JMX connection. To be able to do this, the application needs to have the tools.jar file on the classpath. The tools.jar file is located in the lib directory of the JDK.

In the maven pom.xml file, I have declared this dependency like this:

```
        <dependency>
            <groupId>com.sun</groupId>
            <artifactId>tools</artifactId>
            <version>1.7</version>
            <scope>system</scope>
            <systemPath>${java.home}/lib/tools.jar</systemPath>
        </dependency>
```

Note that the location of the jar is specified using the "java.home" property.
As long as the java.home property is set to the location of the JDK, this will work correctly. If however, it is set to a JRE, the tools.jar file will not be found. Thus in the manifest, I have declared "JDK-Required: true".

However, when the Capsule jar is launched by the user, it may get executed by the JRE. When Capsule resolves the dependencies in nexus, it finds the dependency I mentioned above. The java.home property will be substituted with the home of the running JRE, not with the requested JDK. The required tools.jar file will not be found and the execution will fail.

The solution is to supply the value of the java.home property when constructing the DefaultRepositorySystemSession that will be used to resolve the dependencies.