### PR TITLE
Fix trampolining

### DIFF
--- a/capsule-util/src/main/resources/capsule/trampoline-execheader.sh
+++ b/capsule-util/src/main/resources/capsule/trampoline-execheader.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec `java -Dcapsule.trampoline -jar $0` "$@"
+exec bash -c "exec $(java -Dcapsule.trampoline -jar $0) $@"

--- a/capsule/src/main/java/Capsule.java
+++ b/capsule/src/main/java/Capsule.java
@@ -1263,7 +1263,7 @@ public class Capsule implements Runnable {
         final List<String> cmdline = new ArrayList<>(pb.command());
         cmdline.remove("-D" + PROP_TRAMPOLINE);
         for (int i = 0; i < cmdline.size(); i++)
-            cmdline.set(i, "'" + cmdline.get(i) + "'");
+            cmdline.set(i, "\"" + cmdline.get(i) + "\"");
         return join(cmdline, " ");
     }
 

--- a/capsule/src/test/java/CapsuleTest.java
+++ b/capsule/src/test/java/CapsuleTest.java
@@ -1081,8 +1081,8 @@ public class CapsuleTest {
         assertEquals(0, exit);
         String res = out.toString();
         assert_().that(res).matches("[^\n]+\n\\z"); // a single line, teminated with a newline
-        assert_().that(res).startsWith("'" + "/my/1.7.0.jdk/home/bin/java" + (Capsule.isWindows() ? ".exe" : "") + "'");
-        assert_().that(res).endsWith("'com.acme.Foo' 'hi' 'there!'\n");
+        assert_().that(res).startsWith("\"" + "/my/1.7.0.jdk/home/bin/java" + (Capsule.isWindows() ? ".exe" : "") + "\"");
+        assert_().that(res).endsWith("\"com.acme.Foo\" \"hi\" \"there!\"\n");
     }
 
     private static int main0(Class<?> clazz, String... args) {


### PR DESCRIPTION
Fixes two issues with trampolining:

* Quotes in the trampoline string require it to the executed using "bash -c".
* Windows can handle double quotes in the trampoline string, whereas Unix can handle either single or double quotes. Changing the quoting to use double quotes allows it to work on both platforms.

I considered adding documentation for trampolining by using a custom launch script instead of a really executable header, with Windows support, but didn't really see a good place for it. I can add another commit with documentation changes if we think that would be good.