### PR TITLE
Proposal: add a property to extend classpath at launch time

### DIFF
--- a/capsule/src/main/java/Capsule.java
+++ b/capsule/src/main/java/Capsule.java
@@ -267,6 +267,7 @@ public class Capsule implements Runnable {
     private static final String PROP_CAPSULE_JAVA_HOME = OPTION("capsule.java.home", null, null, "Sets the location of the Java home (JVM installation directory) to use; If \'current\' forces the use of the JVM that launched the capsule.");
     private static final String PROP_CAPSULE_JAVA_CMD = OPTION("capsule.java.cmd", null, null, "Sets the path to the Java executable to use.");
     private static final String PROP_JVM_ARGS = OPTION("capsule.jvm.args", null, null, "Sets additional JVM arguments to use when running the application.");
+    private static final String PROP_RUNTIME_CLASSPATH = OPTION("capsule.classpath", null, null, "Sets additional colon-separated entries that will be appended to the class path.");
     private static final String PROP_PORT = "capsule.port";
     private static final String PROP_ADDRESS = "capsule.address";
     private static final String PROP_TRAMPOLINE = "capsule.trampoline";
@@ -2234,6 +2235,19 @@ public class Capsule implements Runnable {
         classPath.add(lookup("*.jar", ATTR_APP_CLASS_PATH));
 
         classPath.addAll(nullToEmpty(getAttribute(ATTR_DEPENDENCIES)));
+
+        String runtimeClassPath = getProperty(PROP_RUNTIME_CLASSPATH);
+        log(LOG_VERBOSE, "Runtime class path: " + runtimeClassPath);
+        if (runtimeClassPath != null) {
+            for (String entry : split(runtimeClassPath, ":")) {
+                if (entry.isEmpty()) {
+                    continue;
+                }
+                Path abs = toAbsolutePath(Paths.get(entry));
+                log(LOG_DEBUG, "Adding entry " + abs);
+                classPath.add(abs);
+            }
+        }
 
         time("buildClassPath", start);
         return classPath;


### PR DESCRIPTION
_Note: this may be unnecessary; I just couldn't figure out how to do it with the existing implementation. I'd be happy to do this some other way, if you point me in the right direction._

In some circumstances, it may be necessary to extend the classpath for a capsule-packaged application at launch time. For example, consider and extensible application that uses [ServiceLoader](http://docs.oracle.com/javase/7/docs/api/java/util/ServiceLoader.html) to load plugin modules at runtime. If the plugins are not available when the application is packaged into the capsule fat jar, there appears to be no mechanism to add them to the classpath at launch time. 

This patch adds a `capsule.classpath` property that allows the classpath to be extended at startup, e.g.

```
java -Dcapsule.classpath=/some/path/spi-implementation.jar -jar extensible-app-capsule-fat.jar
```

This supersedes older approaches like [caplet classpath injection](https://github.com/danthegoodman/capsule-runtime-classpath) that no longer work due to some Capsule methods becoming private.

