### PR TITLE
Fix for exception when jar contains files more than once

### DIFF
--- a/capsule/src/main/java/Capsule.java
+++ b/capsule/src/main/java/Capsule.java
@@ -3396,6 +3396,11 @@ public class Capsule implements Runnable {
             if (entry.isDirectory() || !shouldExtractFile(entry.getName()))
                 continue;
 
+            if (Files.exists(targetDir.resolve(entry.getName()))) {
+                log(LOG_QUIET, "Warning: duplicate file " + entry.getName() + " in capsule");
+                continue;
+            }
+
             writeFile(targetDir, entry.getName(), jar);
         }
     }


### PR DESCRIPTION
Fixes Issue #79 

If the jar that includes Capsule.class contains a file multiple times (this happened to me when using the capsule gradle plugin, although I'm not sure why), Capsule will croak with an exception. This pull request fixes the bug by preventing extraction of a file that already exists in the cache directory. 

It also tries to do the right thing with regards to a related issue: the cache locking code can die with an exception if Capsule attempts to call lock twice. This probably shouldn't happen unless there's another bug, but when it does the error message is confusing (it throws an OverlappingFilelockException). The jar extraction bug triggers this issue since the exception causes the unlocking code to be bypassed in one instance. The patch here just makes it a little more robust and gives a clearer error message.