### PR TITLE
Make locking more robust by preventing double locking

### DIFF
--- a/capsule/src/main/java/Capsule.java
+++ b/capsule/src/main/java/Capsule.java
@@ -2080,7 +2080,16 @@ public class Capsule implements Runnable {
         log(LOG_VERBOSE, "Locking " + lockFile);
         final FileChannel c = FileChannel.open(lockFile, new HashSet<>(asList(StandardOpenOption.CREATE, StandardOpenOption.WRITE)), getPermissions(dir));
 
-        this.appCacheLock = c.lock();
+        if (this.appCacheLock != null) {
+            // This shouldn't happen, but due to another bug it's possible that the cache was locked and
+            // not released. In this case, attempting to lock again would throw an OverlappingFileLockException,
+            // which is not a very user-friendly solution. Instead, we just log a warning message and attempt to
+            // continue running.
+            log(LOG_QUIET, "Attempting to double lock (ignoring, but this is most likely a bug in CAPSULE)");
+            c.close();
+        } else {
+            this.appCacheLock = c.lock();
+        }
     }
 
     private void unlockAppCache(Path dir) throws IOException {


### PR DESCRIPTION
Bugs in Capsule can cause lockAppCache()  to be called twice without unlocking. When this happens, an OverlappingFileLockException is thrown, which is not easily understandable to the average user (and can also misdirect attention from the bug that actually caused this). 

An example of this:
In buildSystemProperties(),  getAppCache() (which calls lockAppCache()) is called twice: once in buildNativeLibraryPath() and once directly. If  an exception is thrown in extractJar() in the first call, it is caught but the unlocking code is bypassed, so the second call tries to enter the lock again.

This pull request is very minimal, and allows the code to recover from minor problems (logging a message to make sure it is noticed, since it is caused by some other bug). 

A better fix might be to make sure that locking and unlocking happens at the same "code level" (this would make such errors much easier to spot), but it would require much more intrusive changes. 