### PR TITLE
Fix capsule website link in README [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ on Maven Central.
 
 ### Documentation
 
-[Capsule website](www.capsule.io)
+[Capsule website](http://www.capsule.io)
 
 ### Support
 


### PR DESCRIPTION
Leaving out the protocol of the url causes github to treat it like a relative path. 