### PR TITLE
Allow caplets to specify a different lookup class for 'findOwnJarFile'

### DIFF
--- a/capsule/src/main/java/Capsule.java
+++ b/capsule/src/main/java/Capsule.java
@@ -87,7 +87,6 @@ import javax.management.MBeanServer;
 import javax.management.MBeanServerConnection;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
-import javax.management.remote.JMXConnectorServer;
 import javax.management.remote.JMXServiceURL;
 
 import static java.util.Collections.*;

--- a/capsule/src/main/java/Capsule.java
+++ b/capsule/src/main/java/Capsule.java
@@ -1661,8 +1661,12 @@ public class Capsule implements Runnable, InvocationHandler {
         if (ATTR_JAVA_AGENTS == attr) {
             // add the capsule as an agent
             final Map<Object, String> agents = new LinkedHashMap<>(cast(ATTR_JAVA_AGENTS, value));
-            assert isWrapperCapsule() ^ findOwnJarFile().equals(getJarFile());
-            agents.put(processOutgoingPath(findOwnJarFile()), isWrapperCapsule() ? processOutgoingPath(getJarFile()) : "");
+            Path ownJar = null;
+            try {
+                ownJar = findOwnJarFile();
+            } catch (final IllegalStateException ignored) {}
+            if (ownJar != null)
+                agents.put(processOutgoingPath(ownJar), isWrapperCapsule() ? processOutgoingPath(getJarFile()) : "");
             return (T) agents;
         }
 

--- a/capsule/src/test/java/CapsuleAgentTest.java
+++ b/capsule/src/test/java/CapsuleAgentTest.java
@@ -1,0 +1,85 @@
+/*
+ * Capsule
+ * Copyright (c) 2014-2015, Parallel Universe Software Co. All rights reserved.
+ *
+ * This program and the accompanying materials are licensed under the terms
+ * of the Eclipse Public License v1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+import capsule.test.Pair;
+import co.paralleluniverse.capsule.Jar;
+import co.paralleluniverse.capsule.test.CapsuleTestUtils;
+import co.paralleluniverse.common.FlexibleClassLoader;
+import co.paralleluniverse.common.JarClassLoader;
+import co.paralleluniverse.common.PathClassLoader;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author circlespainter
+ */
+public class CapsuleAgentTest {
+	@Test
+	public void testWrapperCapsuleAgent() throws Exception {
+		final Jar wrapper = new Jar()
+				.setAttribute("Manifest-Version", "1.0")
+				.setAttribute("Main-Class", "Capsule")
+				.setAttribute("Premain-Class", "Capsule")
+				.setAttribute("Capsule-Agent", "true")
+				.setAttribute("Caplets", "MyCapsule")
+				.addClass(TestCapsule.class)
+				.addClass(Pair.class)
+				.addClass(JarClassLoader.class)
+				.addClass(PathClassLoader.class)
+				.addClass(FlexibleClassLoader.class)
+				.addClass(MyCapsule.class)
+				.addClass(Capsule.class);
+
+		final Jar app = new Jar()
+				.setAttribute("Manifest-Version", "1.0")
+				.setAttribute("Main-Class", Capsule.class.getName())
+				.setAttribute("Premain-Class", Capsule.class.getName())
+				.setAttribute("Capsule-Agent", "true")
+				.setAttribute("Application-Class", MainTest.class.getName())
+				.addClass(Capsule.class)
+				.addClass(MainTest.class);
+
+		final Path wrapperPath = Files.createTempFile("capsule-agent-test-wrapper", ".jar");
+		CapsuleTestUtils.newCapsule(wrapper, wrapperPath); // Create
+		final Path appPath = Files.createTempFile("capsule-agent-test-app", ".jar");
+		CapsuleTestUtils.newCapsule(app, appPath); // Create
+		final Path cacheDir = Files.createTempDirectory("capsule-agent-test-cache");
+
+		final ProcessBuilder pb = new ProcessBuilder("java", "-jar", wrapperPath.toString(), appPath.toString());
+		pb.environment().put("CAPSULE_CACHE_DIR", cacheDir.toAbsolutePath().toString());
+		assertEquals(0, pb.start().waitFor());
+
+		final Path appCache = cacheDir.resolve("apps").resolve(MainTest.class.getName());
+		assertTrue(Files.exists(appCache.resolve(MyCapsule.WRAPPER_AGENT_OK_FNAME)));
+
+		Files.delete(wrapperPath);
+		Files.delete(appPath);
+		Files.walkFileTree(cacheDir, new SimpleFileVisitor<Path>() {
+			@Override
+			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+				Files.delete(file);
+				return FileVisitResult.CONTINUE;
+			}
+
+			@Override
+			public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+				Files.delete(dir);
+				return FileVisitResult.CONTINUE;
+			}
+		});
+	}
+}

--- a/capsule/src/test/java/CapsuleTest.java
+++ b/capsule/src/test/java/CapsuleTest.java
@@ -11,6 +11,7 @@ import co.paralleluniverse.capsule.Jar;
 import co.paralleluniverse.capsule.test.CapsuleTestUtils;
 import co.paralleluniverse.capsule.test.CapsuleTestUtils.StringPrintStream;
 import static co.paralleluniverse.capsule.test.CapsuleTestUtils.*;
+
 import co.paralleluniverse.common.ZipFS;
 import com.google.common.jimfs.Jimfs;
 import java.io.IOException;
@@ -41,7 +42,6 @@ import org.junit.Before;
 import static com.google.common.truth.Truth.*;
 import java.nio.file.Paths;
 import org.joor.Reflect;
-import org.junit.Ignore;
 //import static org.mockito.Mockito.*;
 
 public class CapsuleTest {
@@ -1206,14 +1206,14 @@ public class CapsuleTest {
                 .addEntry("META-INF/x.txt", emptyInputStream());
 
         Class<?> capsuleClass = loadCapsule(wrapper);
-        setProperties(capsuleClass, props);
+//        setProperties(capsuleClass, props);
 
         Path fooPath = mockDep(capsuleClass, "com.acme:foo", "jar", "com.acme:foo:1.0").get(0);
         Files.createDirectories(fooPath.getParent());
         app.write(fooPath);
 
         props.setProperty("capsule.merge", "out.jar");
-        props.setProperty("capsule.log", "verbose");
+//        props.setProperty("capsule.log", "verbose");
 
         int exit = main0(capsuleClass, "com.acme:foo");
 

--- a/capsule/src/test/java/CapsuleTest.java
+++ b/capsule/src/test/java/CapsuleTest.java
@@ -1556,7 +1556,8 @@ public class CapsuleTest {
         return new Jar()
                 .setAttribute("Manifest-Version", "1.0")
                 .setAttribute("Main-Class", "TestCapsule")
-                .setAttribute("Premain-Class", "TestCapsule");
+                .setAttribute("Premain-Class", "TestCapsule")
+                .setAttribute("Capsule-Agent", "true");
     }
 
     private Jar makeRealCapsuleJar(Jar jar) throws IOException {

--- a/capsule/src/test/java/MainTest.java
+++ b/capsule/src/test/java/MainTest.java
@@ -1,0 +1,10 @@
+import java.util.Arrays;
+
+/**
+ * Created by fabio on 9/29/15.
+ */
+public class MainTest {
+	public static void main(String[] args) {
+		System.out.print(Arrays.toString(args));
+	}
+}

--- a/capsule/src/test/java/MyCapsule.java
+++ b/capsule/src/test/java/MyCapsule.java
@@ -7,6 +7,9 @@
  * http://www.eclipse.org/legal/epl-v10.html
  */
 
+import java.io.IOException;
+import java.lang.instrument.Instrumentation;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,6 +20,8 @@ import java.util.Map;
  * A custom capsule example
  */
 public class MyCapsule extends TestCapsule {
+    public static final String WRAPPER_AGENT_OK_FNAME = "startJMXServer-specialized.empty";
+
     public MyCapsule(Path jarFile) {
         super(jarFile);
     }
@@ -50,6 +55,16 @@ public class MyCapsule extends TestCapsule {
             return (T) args;
         }
         return super.attribute(attr); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    protected void agent(Instrumentation inst) {
+        try {
+            Files.createFile(getWritableAppCache().resolve(WRAPPER_AGENT_OK_FNAME));
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+        super.agent(inst);
     }
 
     @Override

--- a/capsule/src/test/java/TestCapsule.java
+++ b/capsule/src/test/java/TestCapsule.java
@@ -51,7 +51,7 @@ public class TestCapsule extends Capsule {
     public static void mock(String coords, String type, List<Path> paths) {
         if (DEPS == null)
             DEPS = new HashMap<>();
-        DEPS.put(new Pair(coords, type), paths);
+        DEPS.put(new Pair<>(coords, type), paths);
     }
 
     @Override
@@ -68,7 +68,7 @@ public class TestCapsule extends Capsule {
         if (o instanceof String) {
             String x = (String) o;
             if (x.contains(":"))
-                o = new Pair(x, type.isEmpty() ? "jar" : type);
+                o = new Pair<>(x, type.isEmpty() ? "jar" : type);
         }
         return super.lookup0(o, type, attrContext, context); //To change body of generated methods, choose Tools | Templates.
     }


### PR DESCRIPTION
The problematic case is the `capsule-shield` agent capsule not being able to lookup correctly its own JAR file because `Capsule` appears more than once in the classpath (so I think this can happen in other cases too) and the main capsule JAR gets selected instead.

The consequence is that the agent capsule is not detected correctly as a wrapper capsule and its manifest doesn't get read, which results in the caplet's functionality being disabled (specifically, the remote JMX server).

This patch allows caplets to pass a different "own JAR" lookup class by defining their own `premain` in which they'll call `premain0` with a class that will select the correct JAR (typically, the caplet's). The caplet will also define itself as a `Premain-Class` in its own manifest.