### PR TITLE
Fixed handling jdk-* and jre-* Java installation paths

### DIFF
--- a/capsule/src/main/java/Capsule.java
+++ b/capsule/src/main/java/Capsule.java
@@ -4103,8 +4103,11 @@ public class Capsule implements Runnable, InvocationHandler {
             m.find();
             return shortJavaVersion(m.group(1));
         } else if (fileName.startsWith("jdk") || fileName.startsWith("jre") || fileName.endsWith(".jdk") || fileName.endsWith(".jre")) {
-            if (fileName.startsWith("jdk") || fileName.startsWith("jre"))
+            if (fileName.startsWith("jdk-") || fileName.startsWith("jre-"))
+                fileName = fileName.substring(4);
+            else if (fileName.startsWith("jdk") || fileName.startsWith("jre"))
                 fileName = fileName.substring(3);
+
             if (fileName.endsWith(".jdk") || fileName.endsWith(".jre"))
                 fileName = fileName.substring(0, fileName.length() - 4);
             return shortJavaVersion(fileName);

--- a/capsule/src/test/java/CapsuleTest.java
+++ b/capsule/src/test/java/CapsuleTest.java
@@ -1300,6 +1300,8 @@ public class CapsuleTest {
         assertEquals("1.8.0", Capsule.isJavaDir("jdk-8-oracle"));
         assertEquals("1.8.0", Capsule.isJavaDir("jre-8-oracle"));
         assertEquals("1.8.0", Capsule.isJavaDir("jdk-8-oracle-x64"));
+        assertEquals("1.8.0", Capsule.isJavaDir("jdk-1.8.0"));
+        assertEquals("1.8.0", Capsule.isJavaDir("jre-1.8.0"));
     }
 
     @Test


### PR DESCRIPTION
Without this change having paths starting with `jdk-` or `jre-` but without `-openjdk` nor `-oracle` at the end used to return version number like `-1.7.0` which resulted in the following exception:

```
CAPSULE EXCEPTION: Could not parse version: -1.7.0 while processing system property java.home: /usr/lib/jvm/java-1.7.0-openjdk-1.7.0.91.x86_64/jre
java.lang.IllegalArgumentException: Could not parse version: -1.7.0
       at Capsule.parseJavaVersion(Capsule.java:4241)
       at Capsule.getJavaHomes(Capsule.java:4067)
       at Capsule.getJavaHomes(Capsule.java:4032)
       at Capsule.findJavaHome(Capsule.java:2579)
       at Capsule.chooseJavaHome0(Capsule.java:2560)
       at Capsule.chooseJavaHome(Capsule.java:2548)
       at Capsule.getJavaHome(Capsule.java:2532)
       at Capsule.getJavaExecutable0(Capsule.java:2258)
       at Capsule.getJavaExecutable(Capsule.java:2250)
       at Capsule.buildJavaProcess(Capsule.java:2208)
       at Capsule.buildProcess0(Capsule.java:1524)
       at Capsule.buildProcess(Capsule.java:1515)
       at Capsule.prelaunch0(Capsule.java:1488)
       at Capsule.prelaunch(Capsule.java:1481)
       at Capsule.prepareForLaunch(Capsule.java:1334)
       at Capsule.launch(Capsule.java:1263)
       at Capsule.main0(Capsule.java:394)
       at Capsule.main(Capsule.java:374)
```

Workaround for this error at the moment is to explicitly set desired JDK installation path with the use of `-Dcapsule.java.home`.