### PR TITLE
Fix version line on Java 10 and later

### DIFF
--- a/capsule/src/main/java/Capsule.java
+++ b/capsule/src/main/java/Capsule.java
@@ -4160,17 +4160,19 @@ public class Capsule implements Runnable, InvocationHandler {
         return javaHome.resolve("bin").resolve(exec + (isWindows() ? ".exe" : ""));
     }
 
-    private static final Pattern PAT_JAVA_VERSION_LINE = Pattern.compile(".*?\"(.+?)\"");
+    private static final Pattern PAT_JAVA_VERSION_LINE = Pattern.compile(".*?\"(.+?)\".*");
+
+    static String parseJavaVersionLine(String versionLine) {
+        final Matcher m = PAT_JAVA_VERSION_LINE.matcher(versionLine);
+        if (!m.matches())
+            throw new IllegalArgumentException("Could not parse version line: " + versionLine);
+        return m.group(1);
+    }
 
     private static String getActualJavaVersion(Path javaHome) {
         try {
             final String versionLine = first(exec(1, true, new ProcessBuilder(asList(getJavaExecutable0(javaHome).toString(), "-version"))));
-            final Matcher m = PAT_JAVA_VERSION_LINE.matcher(versionLine);
-            if (!m.matches())
-                throw new IllegalArgumentException("Could not parse version line: " + versionLine);
-            final String version = m.group(1);
-
-            return version;
+            return parseJavaVersionLine(versionLine);
         } catch (Exception e) {
             throw rethrow(e);
         }

--- a/capsule/src/test/java/CapsuleTest.java
+++ b/capsule/src/test/java/CapsuleTest.java
@@ -1571,6 +1571,15 @@ public class CapsuleTest {
     }
     //</editor-fold>
 
+    @Test
+    public void testParseJavaVersionLine() {
+        assertEquals("1.8.0_161",   Capsule.parseJavaVersionLine("java version \"1.8.0_161\""));
+        assertEquals("9.0.4",       Capsule.parseJavaVersionLine("java version \"9.0.4\""));
+        assertEquals("10",          Capsule.parseJavaVersionLine("java version \"10\" 2018-03-20"));
+        assertEquals("11",          Capsule.parseJavaVersionLine("java version \"11\" 2018-09-25"));
+        assertEquals("10.0.2",      Capsule.parseJavaVersionLine("openjdk version \"10.0.2\" 2018-07-17"));
+    }
+
     //<editor-fold defaultstate="collapsed" desc="Utilities">
     /////////// Utilities ///////////////////////////////////
     // may be called once per test (always writes jar into /capsule.jar)


### PR DESCRIPTION
This commit fixes the issue when parsing the version line produced by Java 10 and later. It also adds a small unit test to keep check the regexp is working properly.

Solves #129.
