### PR TITLE
Fix PAT_JAVA_VERSION Regex

### DIFF
--- a/capsule/src/main/java/Capsule.java
+++ b/capsule/src/main/java/Capsule.java
@@ -4335,7 +4335,7 @@ public class Capsule implements Runnable, InvocationHandler {
         return true;
     }
 
-    private static final Pattern PAT_JAVA_VERSION = Pattern.compile("(?<major>\\d+)(\\.(?<minor>\\d+))?(?:\\.(?<patch>\\d+))?(_(?<update>\\d+))?(-(?<pre>[^-]+))?(-(?<build>.+))?");
+    private static final Pattern PAT_JAVA_VERSION = Pattern.compile("(?<major>\\d+)(\\.(?<minor>\\d+))?(?:\\.(?<patch>\\d+))?([_.](?<update>\\d+))?(-(?<pre>[^-]+))?(-(?<build>.+))?");
 
     // visible for testing
     static int[] parseJavaVersion(String v) {


### PR DESCRIPTION
The current regex fails to parse `11.0.9.1-internal` due to the `.1` "update" group. This version is coming from openjdk conda forge. See [here](https://github.com/nextflow-io/nextflow/issues/953#issuecomment-888365138) for more details.

This change allows for `_<update>` or `.<update>` in the version string.